### PR TITLE
Support additional ports (beyond just 22)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 
+EXPOSE 8080
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ inventory:
 	@tput sgr0
 
 clean_inventory:
-	@rm inventory
-
+	@-rm inventory
 
 # query our docker containers for their exposed local SSH port (mapping to their internal port 22)
 define docker_inventory_ports
-	docker container ls --filter 'name=ansible-inventory_node*' | awk 'FNR == 1 {next} {print $$1;}' | xargs -I {} docker container port {} | awk '{gsub(/.*-> 0.0.0.0:/," ");}1' 
+	# get all containers in our inventory                       | grab the container ID              | get the port mappings                | extract the TCP ports                    | filter out any other port mappings (only care about TCP ports)
+	docker container ls --filter 'name=ansible-inventory_node*' | awk 'FNR == 1 {next} {print $$1;}' | xargs -I {} docker container port {} | awk '{gsub(/22\/tcp -> 0.0.0.0:/,"");}1' | grep -v -E '.*[-> 0.0.0.0:].*'
 endef

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,3 +4,4 @@ services:
     build: .
     ports: 
       - "22"
+      - "8080"


### PR DESCRIPTION
Added support for generting inventories with containers exposing more
than just port 22 (ssh).  This was mainly an issue for the `Makefile`'s
`docker_inventory_ports` pipe to properly ignore non-ssh ports it may
encounter.

Additionally, added port `8080` as an automatic `EXPOSE` for ease of use
with inventories intended to run web servers.